### PR TITLE
fix: guides, not course

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -30,7 +30,7 @@ const FeatureList: FeatureItem[] = [
     Svg: require("@site/static/img/undraw_docusaurus_react.svg").default,
     description: (
       <>
-        <strong>You</strong> are more than welcome to improve this course.
+        <strong>You</strong> are more than welcome to improve these guides.
         Together we can.
       </>
     ),


### PR DESCRIPTION
Correct copy-paste on landing page.