### PR TITLE
Revert "feat: add "Last updated" date and "Author" to content (#11)"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,8 +33,6 @@ const config = {
         },
         docs: {
           editUrl: `https://github.com/${organizationName}/${projectName}/edit/main`,
-          showLastUpdateAuthor: true,
-          showLastUpdateTime: true,
           sidebarPath: require.resolve("./sidebars.js"),
         },
         theme: {


### PR DESCRIPTION
This reverts commit 3e5149c44a907965f5abf0bc026cd7010a7fddf5.

The author and *Last updated* date is the same on all *docs* pages, maybe because of our GitHub Pages setup.