### PR TITLE
ci: exclude YouTube from broken link checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "broken-link-checker": "blc http://localhost:3000/angular-guides/ --recursive --ordered --exclude https://twitter.com/Thisis_Angular --exclude https://twitter.com/Thisis_Learning --exclude 'https://github.com/this-is-angular/angular-guides/edit/main/*' --exclude 'https://ngrx.io/*' --exclude 'https://angularplayground.it/*' --exclude 'https://docs.devexpress.com/*' --exclude 'https://www.softwaretestinghelp.com/*'"
+    "broken-link-checker": "blc http://localhost:3000/angular-guides/ --recursive --ordered --exclude https://twitter.com/Thisis_Angular --exclude https://twitter.com/Thisis_Learning --exclude 'https://github.com/this-is-angular/angular-guides/edit/main/*' --exclude 'https://ngrx.io/*' --exclude 'https://angularplayground.it/*' --exclude 'https://docs.devexpress.com/*' --exclude 'https://www.softwaretestinghelp.com/*' --exclude 'https://youtu.be/*' --exclude 'https://youtube.com/*'"
   },
   "dependencies": {
     "@algolia/client-search": "^4.13.0",


### PR DESCRIPTION
- Exclude YouTube links from broken link checker to prevent HTTP 429 responses