### PR TITLE
fix: correct link to this-is-angular github

### DIFF
--- a/docs/frameworks-and-libraries/migrate-from-angularjs-to-angular.md
+++ b/docs/frameworks-and-libraries/migrate-from-angularjs-to-angular.md
@@ -3,7 +3,7 @@
 ## Suggested resources
 
 - [Official documentation: Upgrading from AngularJS to Angular](https://angular.io/guide/upgrade)
-- [Migrating an AngularJS Project into an Nx Workspace](https://nx.dev/migration/migration-angularjs)
+- [Migrating an AngularJS Project into an Nx Workspace](https://nx.dev/recipe/migration-angularjs)
 - [Two Approaches to Upgrading Angular Apps by Victor Savkin](https://blog.nrwl.io/two-approaches-to-upgrading-angular-apps-6350b33384e3)
 - [Upgrading Angular Applications: Upgrade Shell by Victor Savkin](https://blog.nrwl.io/upgrading-angular-applications-upgrade-shell-4d4f4a7e7f7b)
 - [Upgrading Angular Applications by Victor Savkin](https://leanpub.com/ngupgrade)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,7 +92,7 @@ const config = {
               },
               {
                 label: "This is Angular on GitHub",
-                href: "https://github.com/this-is-learning",
+                href: "https://github.com/this-is-angular",
               },
             ],
           },


### PR DESCRIPTION
Currently `This is Angular` GitHub link leads to `This is Learning`'s GitHub. Got confused a little bit. Suppose it a typo so this is a quick fix suggestion. But please feel free to close in case it's not relevant by some reason.

<img width="1264" alt="Screenshot 2022-09-04 at 21 59 00" src="https://user-images.githubusercontent.com/19417873/188324874-f0a2f883-4338-4504-8925-e7fa13e07936.png">
